### PR TITLE
Fixing PrivateEntity property name

### DIFF
--- a/Omie.Api.Client/Models/Customer.cs
+++ b/Omie.Api.Client/Models/Customer.cs
@@ -92,7 +92,7 @@ namespace Omie.Api.Client.Models {
 
         /// <remarks/>
         [JsonProperty("pessoa_fisica")]
-        public string IsFisicalPerson { get; set; }
+        public string IsPrivateEntity { get; set; }
 
         /// <remarks/>
         [JsonProperty("razao_social")]

--- a/Omie.Api.Client/Omie.Api.Client.csproj
+++ b/Omie.Api.Client/Omie.Api.Client.csproj
@@ -21,6 +21,8 @@
     
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <DocumentationFile>.\Omie.Api.Client\Omie.Api.Client.xml</DocumentationFile>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
﻿### Description of Change ###

Ive checked that we have some wrong property name 

### Issues Resolved ### 
none

### API Changes ###

Changed:
 - string Customer.IsFisicalPerson => CustomerFake.IsPrivateEntity